### PR TITLE
perf: remove unindexable OR rooms.size = 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Gynzy Notes
-Reason for fork: we needed an index hint to avoid a full collection scan.
+Reason for fork: updated the connection recovery query to exclude broadcasts without a room specified.
+this was not indexable and caused the query to be inefficient
 Deploy: create PR with increased gynzy patch version. specified version will be released on merge
 
 # Socket.IO MongoDB adapter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gynzy/mongo-adapter",
-  "version": "0.3.0-gynzy1",
+  "version": "0.3.0-gynzy2",
   "description": "The Socket.IO MongoDB adapter, allowing to broadcast events between several Socket.IO servers",
   "license": "MIT",
   "repository": {

--- a/test/connection-state-recovery.ts
+++ b/test/connection-state-recovery.ts
@@ -94,7 +94,7 @@ describe("connection state recovery", () => {
       socket.on("disconnect", () => {
         // let's send some packets while the client is disconnected
         socket.emit("myEvent", 1);
-        servers[0].emit("myEvent", 2);
+        servers[0].to("room1").emit("myEvent", 2);
         servers[0].to("room1").emit("myEvent", 3);
 
         // those packets should not be received by the client upon reconnection (room mismatch)

--- a/test/index.ts
+++ b/test/index.ts
@@ -24,10 +24,7 @@ describe("@socket.io/mongodb-adapter", () => {
     await mongoClient.connect();
 
     const collection = mongoClient.db("test").collection("events");
-    await collection.createIndex(
-      { _id: 1, nsp: 1, "data.opts.rooms": 1 },
-      { partialFilterExpression: { type: 3 }, background: true }
-    );
+    await collection.createIndex({ "data.opts.rooms": 1 });
 
     return new Promise((resolve) => {
       for (let i = 1; i <= NODES_COUNT; i++) {


### PR DESCRIPTION
mongodb cannot produce rooms in [] OR rooms.size = 0 from an index
which in turn yields a full collection/ primary key _id scan

all our messages are bound to a room, so for performance reasons
we remove the OR size = 0 clause. all our messages are bound to a
rooms context
